### PR TITLE
Explicitly sort CSV keys

### DIFF
--- a/processors/csv_writer.go
+++ b/processors/csv_writer.go
@@ -2,6 +2,7 @@ package processors
 
 import (
 	"io"
+	"sort"
 
 	"github.com/dailyburn/ratchet/data"
 	"github.com/dailyburn/ratchet/util"
@@ -33,6 +34,10 @@ func (w *CSVWriter) ProcessData(d data.JSON, outputChan chan data.JSON, killChan
 	if w.header == nil {
 		for k := range objects[0] {
 			w.header = append(w.header, k)
+		}
+		sort.Strings(w.header)
+
+		for _, k := range w.header {
 			header_row = append(header_row, util.CSVString(k))
 		}
 	}


### PR DESCRIPTION
Ordering of maps is indeterminate. To ensure reproducibility (and aid in debugging), we'll explicitly sort all CSV headers.