### PR TITLE
Add new HTTPRequest processor.

### DIFF
--- a/processors/http_request.go
+++ b/processors/http_request.go
@@ -1,0 +1,43 @@
+package processors
+
+import (
+	"io"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/dailyburn/ratchet/data"
+	"github.com/dailyburn/ratchet/util"
+)
+
+// HTTPRequest executes an HTTP request and passes along the response body.
+// It is simply wrapping an http.Request and http.Client object. See the
+// net/http docs for more info: https://golang.org/pkg/net/http
+type HTTPRequest struct {
+	Request *http.Request
+	Client  *http.Client
+}
+
+// NewHTTPRequest creates a new HTTPRequest and is essentially wrapping net/http's NewRequest
+// function. See https://golang.org/pkg/net/http/#NewRequest
+func NewHTTPRequest(method, url string, body io.Reader) (*HTTPRequest, error) {
+	req, err := http.NewRequest(method, url, body)
+	return &HTTPRequest{Request: req, Client: &http.Client{}}, err
+}
+
+func (r *HTTPRequest) ProcessData(d data.JSON, outputChan chan data.JSON, killChan chan error) {
+	resp, err := r.Client.Do(r.Request)
+	util.KillPipelineIfErr(err, killChan)
+	if resp != nil && resp.Body != nil {
+		dd, err := ioutil.ReadAll(resp.Body)
+		resp.Body.Close()
+		util.KillPipelineIfErr(err, killChan)
+		outputChan <- dd
+	}
+}
+
+func (r *HTTPRequest) Finish(outputChan chan data.JSON, killChan chan error) {
+}
+
+func (r *HTTPRequest) String() string {
+	return "HTTPRequest"
+}

--- a/processors/http_request_test.go
+++ b/processors/http_request_test.go
@@ -1,0 +1,52 @@
+package processors_test
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/dailyburn/ratchet"
+	"github.com/dailyburn/ratchet/data"
+	"github.com/dailyburn/ratchet/logger"
+	"github.com/dailyburn/ratchet/processors"
+)
+
+func ExampleGetRequest() {
+	logger.LogLevel = logger.LevelSilent
+
+	getGoogle, err := processors.NewHTTPRequest("GET", "http://www.google.com", nil)
+	if err != nil {
+		panic(err)
+	}
+	// this is just a really basic checking function so we can have
+	// determinable example output.
+	checkHTML := processors.NewFuncTransformer(func(d data.JSON) data.JSON {
+		output := "Got HTML?\n"
+		if strings.Contains(strings.ToLower(string(d)), "html") {
+			output += "YES\n"
+		} else {
+			output += "NO\n"
+		}
+		output += "HTML contains Search Google?\n"
+		if strings.Contains(string(d), "Google Search") {
+			output += "YES\n"
+		} else {
+			output += "NO\n"
+		}
+		return data.JSON(output)
+	})
+	stdout := processors.NewIoWriter(os.Stdout)
+	pipeline := ratchet.NewPipeline(getGoogle, checkHTML, stdout)
+
+	err = <-pipeline.Run()
+
+	if err != nil {
+		fmt.Println("An error occurred in the ratchet pipeline:", err.Error())
+	}
+
+	// Output:
+	// Got HTML?
+	// YES
+	// HTML contains Search Google?
+	// YES
+}

--- a/processors/http_request_test.go
+++ b/processors/http_request_test.go
@@ -27,7 +27,7 @@ func ExampleGetRequest() {
 		} else {
 			output += "NO\n"
 		}
-		output += "HTML contains Search Google?\n"
+		output += "HTML contains Google Search?\n"
 		if strings.Contains(string(d), "Google Search") {
 			output += "YES\n"
 		} else {
@@ -47,6 +47,6 @@ func ExampleGetRequest() {
 	// Output:
 	// Got HTML?
 	// YES
-	// HTML contains Search Google?
+	// HTML contains Google Search?
 	// YES
 }


### PR DESCRIPTION
HTTPRequest is a new processor that wraps the built-in
net/http request functionality in a simple yet flexible manner.
Both the http.Request and http.Client attributes are public, so
can be customized fully prior to pipeline execution.