### PR TITLE
ObjectsFromJSON null check

### DIFF
--- a/data/data_test.go
+++ b/data/data_test.go
@@ -46,7 +46,7 @@ func ExampleJSONFromHeaderAndRows() {
 		[]interface{}{4, 5, 6},
 	}
 
-	d := data.JSONFromHeaderAndRows(header, rows)
+	d, _ := data.JSONFromHeaderAndRows(header, rows)
 
 	fmt.Println(fmt.Sprintf("%+v", string(d)))
 	// Output: [{"A":1,"B":2,"C":3},{"A":4,"B":5,"C":6}]

--- a/data/data_test.go
+++ b/data/data_test.go
@@ -39,6 +39,15 @@ func ExampleObjectsFromJSON() {
 	// Output: [map[One:1] map[Two:2]]
 }
 
+func ExampleObjectsFromJSONIsNull() {
+	d := []byte("null")
+
+	objects, _ := data.ObjectsFromJSON(d)
+
+	fmt.Println(fmt.Sprintf("%+v", objects))
+	// Output: []
+}
+
 func ExampleJSONFromHeaderAndRows() {
 	header := []string{"A", "B", "C"}
 	rows := [][]interface{}{

--- a/data/json.go
+++ b/data/json.go
@@ -40,18 +40,25 @@ func ParseJSONSilent(d JSON, v interface{}) error {
 	return json.Unmarshal(d, v)
 }
 
-// ObjectsFromJSON is a helper for parsing a JSON into a slice of
+// ObjectsFromJSON is a helper for parsing JSON into a slice of
 // generic maps/objects. The use-case is when a stage is expecting
 // to receive either a JSON object or an array of JSON objects, and
 // want to deal with it in a generic fashion.
 func ObjectsFromJSON(d JSON) ([]map[string]interface{}, error) {
+	var objects []map[string]interface{}
+
+	// return if we have null instead of object(s).
+	if bytes.Equal(d, []byte("null")) {
+		logger.Debug("ObjectsFromJSON: received null. Expected object or objects. Skipping.")
+		return objects, nil
+	}
+
 	var v interface{}
 	err := ParseJSON(d, &v)
 	if err != nil {
 		return nil, err
 	}
 
-	var objects []map[string]interface{}
 	// check if we have a single object or a slice of objects
 	switch vv := v.(type) {
 	case []interface{}:


### PR DESCRIPTION
I added a guard clause to the ObjectsFromJSON function to return when it just receives a json string containing "null".  I'm not sure if this is the best way/place to do it, but it fixes some issues we been having with our ratchet clients.