### PR TITLE
Logger to print file and line #30

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -2,9 +2,11 @@
 package logger
 
 import (
+	"fmt"
 	"io"
 	"log"
 	"os"
+	"path"
 	"runtime"
 )
 
@@ -31,31 +33,66 @@ var Notifier RatchetNotifier
 // logger.LevelDebug, logger.LevelInfo, logger.LevelError, logger.LevelStatus, or logger.LevelSilent
 var LogLevel = LevelInfo
 
+// LoggerFlag can be set to to log.Lshortfile or log.Llongfile
+// to make the logger print file and line number
+var LoggerFlag = 0
+
+const (
+	Llongfile  = log.Llongfile
+	Lshortfile = log.Lshortfile
+)
+
 var defaultLogger = log.New(os.Stdout, "", log.LstdFlags)
+
+// prefixCaller prepends caller info to variadic the argument v
+func prefixCaller(v ...interface{}) []interface{} {
+	_, file, line, ok := runtime.Caller(2)
+	if ok {
+		args := make([]interface{}, len(v)+1)
+		if LoggerFlag&(log.Lshortfile) != 0 {
+			file = path.Base(file)
+		}
+		args[0] = fmt.Sprintf("%v:%v:", file, line)
+		for i, arg := range v {
+			args[i+1] = arg
+		}
+		return args
+	}
+	return v
+}
 
 // Debug logs output when LogLevel is set to at least Debug level
 func Debug(v ...interface{}) {
-	logit(LevelDebug, v)
+	if LoggerFlag&(log.Lshortfile|log.Llongfile) != 0 {
+		v = prefixCaller(v...)
+	}
+	logit(LevelDebug, v...)
 	if Notifier != nil {
-		Notifier.RatchetNotify(LevelDebug, nil, v)
+		Notifier.RatchetNotify(LevelDebug, nil, v...)
 	}
 }
 
 // Info logs output when LogLevel is set to at least Info level
 func Info(v ...interface{}) {
-	logit(LevelInfo, v)
+	if LoggerFlag&(log.Lshortfile|log.Llongfile) != 0 {
+		v = prefixCaller(v...)
+	}
+	logit(LevelInfo, v...)
 	if Notifier != nil {
-		Notifier.RatchetNotify(LevelInfo, nil, v)
+		Notifier.RatchetNotify(LevelInfo, nil, v...)
 	}
 }
 
 // Error logs output when LogLevel is set to at least Error level
 func Error(v ...interface{}) {
-	logit(LevelError, v)
+	if LoggerFlag&(log.Lshortfile|log.Llongfile) != 0 {
+		v = prefixCaller(v...)
+	}
+	logit(LevelError, v...)
 	if Notifier != nil {
 		trace := make([]byte, 4096)
 		runtime.Stack(trace, true)
-		Notifier.RatchetNotify(LevelError, trace, v)
+		Notifier.RatchetNotify(LevelError, trace, v...)
 	}
 }
 
@@ -63,18 +100,24 @@ func Error(v ...interface{}) {
 // but doesn't send the stack trace to Notifier. This is useful only when
 // using a RatchetNotifier implementation.
 func ErrorWithoutTrace(v ...interface{}) {
-	logit(LevelError, v)
+	if LoggerFlag&(log.Lshortfile|log.Llongfile) != 0 {
+		v = prefixCaller(v...)
+	}
+	logit(LevelError, v...)
 	if Notifier != nil {
-		Notifier.RatchetNotify(LevelError, nil, v)
+		Notifier.RatchetNotify(LevelError, nil, v...)
 	}
 }
 
 // Status logs output when LogLevel is set to at least Status level
 // Status output is high-level status events like stages starting/completing.
 func Status(v ...interface{}) {
-	logit(LevelStatus, v)
+	if LoggerFlag&(log.Lshortfile|log.Llongfile) != 0 {
+		v = prefixCaller(v...)
+	}
+	logit(LevelStatus, v...)
 	if Notifier != nil {
-		Notifier.RatchetNotify(LevelStatus, nil, v)
+		Notifier.RatchetNotify(LevelStatus, nil, v...)
 	}
 }
 


### PR DESCRIPTION
I've made some changes to the logger to enabling printing of file and line number. My intended use for ratchet is a scenario where other people will write many custom data processors. Being able to print above info helps when making sense of unfamiliar code.

There is also a bug in how the variadic argument is passed on to `logit` and `Notifier.RatchetNotify`. It was missing the trailing ellipses. In effect the first arg then becomes `[]interface{}`. If someone is using a regex to parse log output it might now be thrown off because the square brackets are missing. Maybe this shouldn't be fixed?
