### PR TITLE
Add interface to make testing pipelines easier

### DIFF
--- a/pipeline.go
+++ b/pipeline.go
@@ -26,6 +26,12 @@ type Pipeline struct {
 	wg           sync.WaitGroup
 }
 
+// PipelineIface provides an interface to enable mocking the Pipeline.
+// This makes unit testing your code that uses pipelines easier.
+type PipelineIface interface {
+	Run() chan error
+}
+
 // NewPipeline creates a new pipeline ready to run the given DataProcessors.
 // For more complex use-cases, see NewBranchingPipeline.
 func NewPipeline(processors ...DataProcessor) *Pipeline {


### PR DESCRIPTION
Adding an interface for the type with the receiver of a public method makes testing code using pipelines much easier. This style was learned from the AWS Go SDK implementation of provided interfaces to facilitate testing.

Here is [the documentation for one of those](https://docs.aws.amazon.com/sdk-for-go/api/service/dynamodb/dynamodbiface/) in the AWS Go SDK.

For example of how I use this, I have a helper package that provides a method returning a ratchet.PipelineIface. Since this is an interface, I can mock the underlying implementation (of the Run method). An example test looks like this:

``` go
func TestRun_err(t *testing.T) {
	ctrl := gomock.NewController(t)
	defer ctrl.Finish()
	mockPipeline := mock_ratchet.NewMockPipelineIface(ctrl)
	killChan := make(chan error, 1)
	tErr := "testErr"
	killChan <- errors.New(tErr)
	mockPipeline.EXPECT().Run().Return(killChan)
	mockRatchetUtil := mock_uratchet.NewMockHelper(ctrl)
	mockRatchetUtil.EXPECT().NewPipeline(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockPipeline)
	ratchetUtil = mockRatchetUtil
	etl := New()
	recs := []*kinesisstreamsevt.EventRecord{}
	if got := etl.Run(recs); got.Error() != tErr {
		t.Errorf("unexpected error; got: %s, want: %s", got.Error(), tErr)
	}
}
```

Keep in mind, this is testing my `Run` method which is on my ETL object. It is not testing the `Run` method on the Pipeline. I simply need to ensure that my method called `Run` on the `ratchet.Pipeline` and that my method behaved correctly when an error was received on the `killChan`.

I really like how simple this makes testing, even though it may seem superfluous in this case. After, using the AWS Go SDK for several months now, I am convinced that every type providing public methods should likewise provide an interface, even if only for this purpose.