### PR TITLE
Fix issue where processData works sequentially

### DIFF
--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -4,12 +4,146 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"testing"
+	"time"
 
 	"github.com/dailyburn/ratchet"
 	"github.com/dailyburn/ratchet/data"
 	"github.com/dailyburn/ratchet/logger"
 	"github.com/dailyburn/ratchet/processors"
 )
+
+// dummyProcessorDuration is the amount of time ProcessData will spend waiting before it returns.
+const dummyProcessorDuration = 3
+
+// dummyProcessorConcurrency is the number of concurrent calls to ProcessData a dummyConcurrentProcessor object can make at a time.
+const dummyProcessorConcurrency = 2
+
+// dummyReader is a simple stream which pulls values in order from an array.
+type dummyReader struct {
+	data [4]string
+}
+
+func (dr *dummyReader) String() string {
+	return "dummyReader"
+}
+
+func (dr *dummyReader) ProcessData(d data.JSON, outputChan chan data.JSON, killChan chan error) {
+	for i := range dr.data {
+		outputChan <- data.JSON([]byte(dr.data[i]))
+	}
+}
+
+func (dr *dummyReader) Finish(outputChan chan data.JSON, killChan chan error) {
+}
+
+// dummyConcurrentProcessor is an object designed to allow easy testing of the methods used by ConcurrentDataProcessors.
+type dummyConcurrentProcessor struct{}
+
+func (dp *dummyConcurrentProcessor) String() string {
+	return "dummyConcurrentProcessor"
+}
+
+func (dp *dummyConcurrentProcessor) Concurrency() int {
+	return dummyProcessorConcurrency
+}
+
+func (dp *dummyConcurrentProcessor) ProcessData(d data.JSON, outputChan chan data.JSON, killChan chan error) {
+	time.Sleep(dummyProcessorDuration * time.Second)
+	outputChan <- d
+}
+
+func (dp *dummyConcurrentProcessor) Finish(outputChan chan data.JSON, killChan chan error) {
+}
+
+// dummyProcessor is an object designed to allow easy testing of the methods used by DataProcessors.
+type dummyProcessor struct{}
+
+func (dp *dummyProcessor) String() string {
+	return "dummyProcessor"
+}
+
+func (dp *dummyProcessor) ProcessData(d data.JSON, outputChan chan data.JSON, killChan chan error) {
+	time.Sleep(dummyProcessorDuration * time.Second)
+	outputChan <- d
+}
+
+func (dp *dummyProcessor) Finish(outputChan chan data.JSON, killChan chan error) {
+}
+
+// dummyWriter is a simple store of array values.
+type dummyWriter struct {
+	i    int
+	data [4]string
+}
+
+func (dw *dummyWriter) String() string {
+	return "dummyWriter"
+}
+
+func (dw *dummyWriter) ProcessData(d data.JSON, outputChan chan data.JSON, killChan chan error) {
+	dw.data[dw.i] = string(d)
+	dw.i++
+}
+
+func (dw *dummyWriter) Finish(outputChan chan data.JSON, killChan chan error) {
+}
+
+func TestDataProcessor(t *testing.T) {
+	logger.LogLevel = logger.LevelDebug
+
+	data := [4]string{"hi", "there", "guys", "!"}
+	writer := dummyWriter{}
+	pipeline := ratchet.NewPipeline(&dummyReader{data: data}, &dummyProcessor{}, &writer)
+
+	start := time.Now()
+	err := <-pipeline.Run()
+	end := time.Now()
+
+	// This should take about
+	// (len(data) * dummyProcessorDuration) + 1
+	// seconds to finish.
+	//
+	// One second is added to account for other processing time.
+	expectedDuration := time.Duration((len(data)*dummyProcessorDuration)+1) * time.Second
+	if end.Sub(start) > expectedDuration {
+		t.Errorf("Expected pipeline to finish in ~%s, finished in %s", expectedDuration, end.Sub(start))
+	}
+	if err != nil {
+		t.Error("An error occurred in the ratchet pipeline:", err.Error())
+	}
+	if data != writer.data {
+		t.Errorf("Expected %#v to be passed through the pipeline, got %#v", data, writer.data)
+	}
+}
+
+func TestConcurrentDataProcessor(t *testing.T) {
+	logger.LogLevel = logger.LevelDebug
+
+	data := [4]string{"hi", "there", "guys", "!"}
+	writer := dummyWriter{}
+	pipeline := ratchet.NewPipeline(&dummyReader{data: data}, &dummyConcurrentProcessor{}, &writer)
+
+	start := time.Now()
+	err := <-pipeline.Run()
+	end := time.Now()
+
+	// This should take about
+	// (len(data) * dummyProcessorDuration / dummyConcurrentProcessorConcurrency) + 1
+	// seconds to finish.
+	//
+	// One second is added to account for other processing time.
+	expectedDuration := time.Duration((len(data)*dummyProcessorDuration/dummyProcessorConcurrency)+1) * time.Second
+	if end.Sub(start) > expectedDuration {
+		t.Errorf("Expected pipeline to finish in ~%s, finished in %s", expectedDuration, end.Sub(start))
+	}
+	if err != nil {
+		t.Error("An error occurred in the ratchet pipeline:", err.Error())
+	}
+	if data != writer.data {
+		t.Errorf("Expected %#v to be passed through the pipeline, got %#v", data, writer.data)
+	}
+}
 
 func ExampleNewPipeline() {
 	logger.LogLevel = logger.LevelSilent


### PR DESCRIPTION
The call to `processData` was waiting on the `exit` channel to return, which meant that `ConcurrentDataProcessor`s did not run concurrently in practice.  I fixed the issue and added some tests verifying that the time taken is roughly correct for both `ConcurrentDataProcessor`s and `DataProcessor`s.

Fixes #37.

Thanks for the great library, BTW!